### PR TITLE
feat: Allow assigning a resource policy, allow assigning a KMS key, fix errors with secret setup

### DIFF
--- a/API.md
+++ b/API.md
@@ -162,4 +162,19 @@ The name of the IAM user to create.
 ---
 
 
+---
+
+##### `secretResourcePolicy`<sup>Optional</sup> <a name="secretResourcePolicy" id="@renovosolutions/cdk-library-aws-ses-smtp-credentials.SesSmtpCredentialsProps.property.secretResourcePolicy"></a>
+
+```typescript
+public readonly secretResourcePolicy: PolicyDocument;
+```
+
+- *Type:* aws-cdk-lib.aws_iam.PolicyDocument
+
+The resource policy to apply to the resulting secret.
+
+---
+
+
 

--- a/API.md
+++ b/API.md
@@ -146,7 +146,7 @@ const sesSmtpCredentialsProps: SesSmtpCredentialsProps = { ... }
 | **Name** | **Type** | **Description** |
 | --- | --- | --- |
 | <code><a href="#@renovosolutions/cdk-library-aws-ses-smtp-credentials.SesSmtpCredentialsProps.property.iamUserName">iamUserName</a></code> | <code>string</code> | The name of the IAM user to create. |
-| <code><a href="#@renovosolutions/cdk-library-aws-ses-smtp-credentials.SesSmtpCredentialsProps.property.kmsKey">kmsKey</a></code> | <code>aws-cdk-lib.aws_kms.IKey</code> | The KMS key to use for encrypting the secret. |
+| <code><a href="#@renovosolutions/cdk-library-aws-ses-smtp-credentials.SesSmtpCredentialsProps.property.kmsKey">kmsKey</a></code> | <code>aws-cdk-lib.aws_kms.IKey</code> | The KMS key to use for the secret. |
 | <code><a href="#@renovosolutions/cdk-library-aws-ses-smtp-credentials.SesSmtpCredentialsProps.property.overwriteSecret">overwriteSecret</a></code> | <code>boolean</code> | If a secret already exists should it be overwritten? |
 | <code><a href="#@renovosolutions/cdk-library-aws-ses-smtp-credentials.SesSmtpCredentialsProps.property.restoreSecret">restoreSecret</a></code> | <code>boolean</code> | If a secret is pending deletion should it be restored? |
 | <code><a href="#@renovosolutions/cdk-library-aws-ses-smtp-credentials.SesSmtpCredentialsProps.property.secretResourcePolicy">secretResourcePolicy</a></code> | <code>aws-cdk-lib.aws_iam.PolicyDocument</code> | The resource policy to apply to the resulting secret. |
@@ -174,7 +174,7 @@ public readonly kmsKey: IKey;
 - *Type:* aws-cdk-lib.aws_kms.IKey
 - *Default:* default key
 
-The KMS key to use for encrypting the secret.
+The KMS key to use for the secret.
 
 ---
 

--- a/API.md
+++ b/API.md
@@ -146,6 +146,10 @@ const sesSmtpCredentialsProps: SesSmtpCredentialsProps = { ... }
 | **Name** | **Type** | **Description** |
 | --- | --- | --- |
 | <code><a href="#@renovosolutions/cdk-library-aws-ses-smtp-credentials.SesSmtpCredentialsProps.property.iamUserName">iamUserName</a></code> | <code>string</code> | The name of the IAM user to create. |
+| <code><a href="#@renovosolutions/cdk-library-aws-ses-smtp-credentials.SesSmtpCredentialsProps.property.kmsKey">kmsKey</a></code> | <code>aws-cdk-lib.aws_kms.IKey</code> | The KMS key to use for encrypting the secret. |
+| <code><a href="#@renovosolutions/cdk-library-aws-ses-smtp-credentials.SesSmtpCredentialsProps.property.overwriteSecret">overwriteSecret</a></code> | <code>boolean</code> | If a secret already exists should it be overwritten? |
+| <code><a href="#@renovosolutions/cdk-library-aws-ses-smtp-credentials.SesSmtpCredentialsProps.property.restoreSecret">restoreSecret</a></code> | <code>boolean</code> | If a secret is pending deletion should it be restored? |
+| <code><a href="#@renovosolutions/cdk-library-aws-ses-smtp-credentials.SesSmtpCredentialsProps.property.secretResourcePolicy">secretResourcePolicy</a></code> | <code>aws-cdk-lib.aws_iam.PolicyDocument</code> | The resource policy to apply to the resulting secret. |
 
 ---
 
@@ -161,6 +165,46 @@ The name of the IAM user to create.
 
 ---
 
+##### `kmsKey`<sup>Optional</sup> <a name="kmsKey" id="@renovosolutions/cdk-library-aws-ses-smtp-credentials.SesSmtpCredentialsProps.property.kmsKey"></a>
+
+```typescript
+public readonly kmsKey: IKey;
+```
+
+- *Type:* aws-cdk-lib.aws_kms.IKey
+- *Default:* default key
+
+The KMS key to use for encrypting the secret.
+
+---
+
+##### `overwriteSecret`<sup>Optional</sup> <a name="overwriteSecret" id="@renovosolutions/cdk-library-aws-ses-smtp-credentials.SesSmtpCredentialsProps.property.overwriteSecret"></a>
+
+```typescript
+public readonly overwriteSecret: boolean;
+```
+
+- *Type:* boolean
+- *Default:* true
+
+If a secret already exists should it be overwritten?
+
+This helps in cases where cloudformation creates a secret successfully but it gets orphaned for some reason.
+
+---
+
+##### `restoreSecret`<sup>Optional</sup> <a name="restoreSecret" id="@renovosolutions/cdk-library-aws-ses-smtp-credentials.SesSmtpCredentialsProps.property.restoreSecret"></a>
+
+```typescript
+public readonly restoreSecret: boolean;
+```
+
+- *Type:* boolean
+- *Default:* true
+
+If a secret is pending deletion should it be restored?
+
+This helps in cases where cloudformation roll backs puts a secret in pending delete state.
 
 ---
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,7 @@ import {
   Names,
   Stack,
   Tags,
+  aws_kms as kms,
 } from 'aws-cdk-lib';
 import { Construct } from 'constructs';
 
@@ -24,6 +25,28 @@ export interface SesSmtpCredentialsProps {
    * The resource policy to apply to the resulting secret
    */
   readonly secretResourcePolicy?: iam.PolicyDocument;
+  /**
+   * If a secret is pending deletion should it be restored?
+   *
+   * This helps in cases where cloudformation roll backs puts a secret in pending delete state.
+   *
+   * @default true
+   */
+  readonly restoreSecret?: boolean;
+  /**
+   * If a secret already exists should it be overwritten?
+   *
+   * This helps in cases where cloudformation creates a secret successfully but it gets orphaned for some reason.
+   *
+   * @default true
+   */
+  readonly overwriteSecret?: boolean;
+  /**
+   * The KMS key to use for the secret
+   *
+   * @default - default key
+   */
+  readonly kmsKey?: kms.IKey;
 }
 
 export class SesSmtpCredentials extends Construct {
@@ -61,40 +84,57 @@ export class SesSmtpCredentials extends Construct {
 
     Tags.of(this.iamUser).add('CfnStackIdForSesCredLibrary', Stack.of(this).stackId);
 
+    const lambdaPolicy = new iam.ManagedPolicy(this, 'SecretsManagerPolicy', {
+      statements: [
+        new iam.PolicyStatement({
+          effect: iam.Effect.ALLOW,
+          sid: 'SecretsManagerPolicy',
+          actions: [
+            'secretsmanager:PutSecretValue',
+            'secretsmanager:CreateSecret',
+            'secretsmanager:DeleteSecret',
+            'secretsmanager:UpdateSecret',
+            'secretsmanager:TagResource',
+            'secretsmanager:RestoreSecret',
+          ],
+          resources: [`arn:aws:secretsmanager:${Stack.of(this).region}:${Stack.of(this).account}:secret:${secretName}-*`],
+        }),
+        new iam.PolicyStatement({
+          effect: iam.Effect.ALLOW,
+          sid: 'IamAllowKeyManagementPolicy',
+          actions: [
+            'iam:CreateAccessKey',
+            'iam:DeleteAccessKey',
+            'iam:ListAccessKeys',
+          ],
+          resources: ['*'],
+          conditions: {
+            StringEquals: {
+              'iam:ResourceTag/CfnStackIdForSesCredLibrary': Stack.of(this).stackId,
+            },
+          },
+        }),
+      ],
+    });
+
+    if (props.kmsKey) {
+      lambdaPolicy.addStatements(new iam.PolicyStatement({
+        effect: iam.Effect.ALLOW,
+        sid: 'KmsAllowKeyManagementPolicy',
+        actions: [
+          'kms:Encrypt',
+          'kms:Decrypt',
+          'kms:ReEncrypt*',
+          'kms:GenerateDataKey*',
+        ],
+        resources: [props.kmsKey.keyArn],
+      }));
+    }
+
     const role = new iam.Role(this, 'Role', {
       assumedBy: new iam.ServicePrincipal('lambda.amazonaws.com'),
       managedPolicies: [
-        new iam.ManagedPolicy(this, 'SecretsManagerPolicy', {
-          statements: [
-            new iam.PolicyStatement({
-              effect: iam.Effect.ALLOW,
-              sid: 'SecretsManagerPolicy',
-              actions: [
-                'secretsmanager:PutSecretValue',
-                'secretsmanager:CreateSecret',
-                'secretsmanager:DeleteSecret',
-                'secretsmanager:UpdateSecret',
-                'secretsmanager:TagResource',
-              ],
-              resources: [`arn:aws:secretsmanager:${Stack.of(this).region}:${Stack.of(this).account}:secret:${secretName}-*`],
-            }),
-            new iam.PolicyStatement({
-              effect: iam.Effect.ALLOW,
-              sid: 'IamAllowKeyManagementPolicy',
-              actions: [
-                'iam:CreateAccessKey',
-                'iam:DeleteAccessKey',
-                'iam:ListAccessKeys',
-              ],
-              resources: ['*'],
-              conditions: {
-                StringEquals: {
-                  'iam:ResourceTag/CfnStackIdForSesCredLibrary': Stack.of(this).stackId,
-                },
-              },
-            }),
-          ],
-        }),
+        lambdaPolicy,
       ],
     });
 
@@ -116,7 +156,9 @@ export class SesSmtpCredentials extends Construct {
         UserName: props.iamUserName,
         SecretName: secretName,
         Region: Stack.of(this).region,
-        Override: 'true',
+        Override: props.overwriteSecret ?? true,
+        Restore: props.restoreSecret ?? true,
+        KmsKeyId: props.kmsKey == undefined ? 'aws/secretsmanager' : props.kmsKey.keyId,
       },
     });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,6 +20,10 @@ export interface SesSmtpCredentialsProps {
    * The name of the IAM user to create
    */
   readonly iamUserName: string;
+  /**
+   * The resource policy to apply to the resulting secret
+   */
+  readonly secretResourcePolicy?: iam.PolicyDocument;
 }
 
 export class SesSmtpCredentials extends Construct {
@@ -119,5 +123,12 @@ export class SesSmtpCredentials extends Construct {
     secret.node.addDependency(this.iamUser);
 
     this.secret = secretsmanager.Secret.fromSecretCompleteArn(this, 'Secret', secret.getAttString('SecretArn'));
+
+    if (props.secretResourcePolicy) {
+      new secretsmanager.CfnResourcePolicy(this, 'SecretResourcePolicy', {
+        secretId: this.secret.secretArn,
+        resourcePolicy: props.secretResourcePolicy.toString(),
+      });
+    }
   }
 }

--- a/test/__snapshots__/index.test.ts.snap
+++ b/test/__snapshots__/index.test.ts.snap
@@ -19,7 +19,7 @@ Object {
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "71154ed5bf6922b5d96b32ae1b3fea1d56f5874382ad8dc7e4421d5ed827ae52.zip",
+          "S3Key": "7224866b0a593c509766adc7e7d3386a8672fd9077269c679594700a955d44d1.zip",
         },
         "Handler": "index.on_event",
         "Role": Object {
@@ -169,10 +169,12 @@ Object {
         "SesSmtpCredentialsUserE9E5FC46",
       ],
       "Properties": Object {
-        "Override": "true",
+        "KmsKeyId": "aws/secretsmanager",
+        "Override": true,
         "Region": Object {
           "Ref": "AWS::Region",
         },
+        "Restore": true,
         "SecretName": "TestStackSesSmtpCredentials1AD8F67EexampleUser",
         "ServiceToken": Object {
           "Fn::GetAtt": Array [
@@ -184,6 +186,57 @@ Object {
       },
       "Type": "AWS::CloudFormation::CustomResource",
       "UpdateReplacePolicy": "Delete",
+    },
+    "SesSmtpCredentialsSecretResourcePolicyFA18D550": Object {
+      "Properties": Object {
+        "ResourcePolicy": Object {
+          "Statement": Array [
+            Object {
+              "Action": "secretsmanager:GetSecretValue",
+              "Condition": Object {
+                "ArnLike": Object {
+                  "aws:SourceArn": Object {
+                    "Fn::Join": Array [
+                      "",
+                      Array [
+                        "arn:aws:rds:",
+                        Object {
+                          "Ref": "AWS::Region",
+                        },
+                        ":",
+                        Object {
+                          "Ref": "AWS::AccountId",
+                        },
+                        ":og:teststack*",
+                      ],
+                    ],
+                  },
+                },
+                "StringEquals": Object {
+                  "aws:sourceAccount": Array [
+                    Object {
+                      "Ref": "AWS::AccountId",
+                    },
+                  ],
+                },
+              },
+              "Effect": "Allow",
+              "Principal": Object {
+                "Service": "rds.amazonaws.com",
+              },
+              "Resource": "*",
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "SecretId": Object {
+          "Fn::GetAtt": Array [
+            "SesSmtpCredentialsSecretArn7500943E",
+            "SecretArn",
+          ],
+        },
+      },
+      "Type": "AWS::SecretsManager::ResourcePolicy",
     },
     "SesSmtpCredentialsSecretsManagerPolicyC597B13A": Object {
       "Properties": Object {
@@ -198,6 +251,7 @@ Object {
                 "secretsmanager:DeleteSecret",
                 "secretsmanager:UpdateSecret",
                 "secretsmanager:TagResource",
+                "secretsmanager:RestoreSecret",
               ],
               "Effect": "Allow",
               "Resource": Object {

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1,6 +1,7 @@
 import {
   Stack,
   App,
+  aws_iam as iam,
 } from 'aws-cdk-lib';
 import { Template } from 'aws-cdk-lib/assertions';
 import {
@@ -13,6 +14,24 @@ test('Snapshot', () => {
 
   new SesSmtpCredentials(stack, 'SesSmtpCredentials', {
     iamUserName: 'exampleUser',
+    secretResourcePolicy: new iam.PolicyDocument({
+      statements: [
+        new iam.PolicyStatement({
+          actions: ['secretsmanager:GetSecretValue'],
+          effect: iam.Effect.ALLOW,
+          principals: [new iam.ServicePrincipal('rds.amazonaws.com')],
+          resources: ['*'],
+          conditions: {
+            StringEquals: {
+              'aws:sourceAccount': [Stack.of(stack).account],
+            },
+            ArnLike: {
+              'aws:SourceArn': `arn:aws:rds:${Stack.of(stack).region}:${Stack.of(stack).account}:og:${Stack.of(stack).stackName.toLowerCase()}*`,
+            },
+          },
+        }),
+      ],
+    }),
   });
 
   expect(Template.fromStack(stack)).toMatchSnapshot();


### PR DESCRIPTION
- Errors would occur when a secret was rolled back and deleted. By default the secret is now restored and overwritten.
- Errors would occur when a secret already existed. By default the secret is now overwritten
- Errors would occur with secret retrieval in cross account use cases. You can now define a KMS key besides the default to resolve these errors
- Errors would occur with secret retrieval from AWS services because a resource policy could not be applied. This can now be applied

Closes #11
Closes #14